### PR TITLE
Questionable dep's can also be rerouted as error output

### DIFF
--- a/src/NDepCheck.Tests/MainTests.cs
+++ b/src/NDepCheck.Tests/MainTests.cs
@@ -1,4 +1,4 @@
-// (c) HMMüller 2006...2010
+// (c) thoemmi, hmmueller 2006...2014
 
 using System;
 using System.Collections.Generic;
@@ -12,9 +12,11 @@ namespace NDepCheck.Tests {
     /// </remarks>
     [TestClass]
     public class MainTests {
-        private static readonly string TestAssemblyPath = Path.Combine(Path.GetDirectoryName(typeof (MainTests).Assembly.Location), "NDepCheck.TestAssembly.dll");
+        private static readonly string TestAssemblyPath = Path.Combine(Path.GetDirectoryName(typeof(MainTests).Assembly.Location), "NDepCheck.TestAssembly.dll");
 
+        // ReSharper disable UnusedParameter.Local This is an Assert method, therefore the use of s in an Assert is a real use.
         private static void AssertNotContains(string path, string s) {
+            // ReSharper restore UnusedParameter.Local
             using (TextReader tr = new StreamReader(path)) {
                 string all = tr.ReadToEnd();
                 Assert.IsFalse(all.Contains(s), all);
@@ -374,5 +376,23 @@ NDepCheck.Tests ---> **
                 File.Delete(depFile);
             }
         }
+
+        [TestMethod]
+        public void TestEmitQuestionableDependenciesToErrorLog() {
+            {
+                string depFile = Path.GetTempFileName();
+                using (TextWriter tw = new StreamWriter(depFile)) {
+                    tw.Write(@"
+                    NDepCheck.TestAssembly.** ---> NDepCheck.TestAssembly.**
+                    NDepCheck.TestAssembly.** ---> System.**
+                    NDepCheck.TestAssembly.dir1.dir2.SomeClass::* ---? NamespacelessTestClassForNDepCheck::I
+                    * ---? System.*
+                ");
+                }
+                Assert.AreEqual(0, Program.Main(new[] { "-x=" + depFile, "/e", TestAssemblyPath }));
+                File.Delete(depFile);
+            }
+        }
+
     }
 }

--- a/src/NDepCheck/Dependency.cs
+++ b/src/NDepCheck/Dependency.cs
@@ -130,6 +130,15 @@ namespace NDepCheck {
         /// not allowed.
         /// </summary>
         /// <returns></returns>
+        public string QuestionableMessage() {
+            return "Questionable dependency " + _usingItem + " ---> " + _usedItem;
+        }
+
+        /// <summary>
+        /// A message presented to the user of this Dependency is
+        /// not allowed.
+        /// </summary>
+        /// <returns></returns>
         public string IllegalMessage() {
             return "Illegal dependency " + _usingItem + " ---> " + _usedItem;
         }

--- a/src/NDepCheck/DependencyChecker.cs
+++ b/src/NDepCheck/DependencyChecker.cs
@@ -16,10 +16,11 @@ namespace NDepCheck {
         /// with <c>AddDependencyRules</c>.
         /// </summary>
         /// <returns>true if no dependencies is illegal according to our rules</returns>
-        public bool Check(IEnumerable<DependencyRuleGroup> groups, IEnumerable<Dependency> dependencies, bool showUnusedQuestionableRules) {
+        public bool Check(IEnumerable<DependencyRuleGroup> groups, IEnumerable<Dependency> dependencies,
+                          bool showUnusedQuestionableRules, bool emitQuestionableDependenciesToErrorLog) {
             bool result = true;
             foreach (var g in groups) {
-                result &= g.Check(dependencies);
+                result &= g.Check(dependencies, emitQuestionableDependenciesToErrorLog);
             }
             foreach (DependencyRuleRepresentation r in _representations) {
                 if (showUnusedQuestionableRules && r.IsQuestionableRule && !r.WasHit) {

--- a/src/NDepCheck/DependencyGrapher.cs
+++ b/src/NDepCheck/DependencyGrapher.cs
@@ -100,7 +100,7 @@ namespace NDepCheck {
             } else if (usingMatch == "" || usedMatch == "") {
                 // ignore this edge!
             } else {
-                bool isOk = _checker.Check(ruleSet, new List<Dependency> {d}, false);
+                bool isOk = _checker.Check(ruleSet, new List<Dependency> {d}, false, false);
 
                 // Filter out loops that are ok - they are not shown.
                 // All other edges (non-loops; and non-ok loops) are shown.

--- a/src/NDepCheck/Options.cs
+++ b/src/NDepCheck/Options.cs
@@ -30,6 +30,8 @@ namespace NDepCheck {
 
         public bool ShowUnusedQuestionableRules { get; set; }
 
+        public bool EmitQuestionableDependenciesToErrorLog { get; set; }
+
         /// <value>
         /// Mark output of <c>DependencyGrapher</c>
         /// as verbose.
@@ -92,6 +94,8 @@ namespace NDepCheck {
                     DotFilename = filename;
                 } else if (arg == "-q" || arg == "/q") {
                     ShowUnusedQuestionableRules = false;
+                } else if (arg == "-e" || arg == "/e") {
+                    EmitQuestionableDependenciesToErrorLog = true;
                 } else if (arg == "-t" || arg == "/t") {
                     ShowTransitiveEdges = true;
                 } else if (arg.StartsWith("-i") || arg.StartsWith("/i")) {
@@ -127,7 +131,7 @@ namespace NDepCheck {
 
         private static void WriteVersion() {
             Log.WriteInfo("NDepCheck V." + typeof(Program).Assembly.GetName().Version.ToString(2) +
-                      " (c) HMMüller, Th.Freudenberg 2006...2010");
+                      " (c) HMMüller, Th.Freudenberg 2007...2014");
         }
 
         private static int UsageAndExit(string message) {
@@ -176,6 +180,10 @@ Options:
          dependency in the DOT graph. N is the maximum width of strings 
          used; the default is 80. Graphs can become quite cluttered 
          with this option.
+
+   /e    Write questionable dependencies as errors (instead of warnings).
+
+   /q    Suppress output of unused questionable (---?) rules.
 
    /v    Verbose. Shows regular expressions used for checking and 
          all checked dependencies. Attention: Place /v BEFORE any

--- a/src/NDepCheck/Program.cs
+++ b/src/NDepCheck/Program.cs
@@ -59,7 +59,7 @@ namespace NDepCheck {
                     try {
                        IEnumerable<Dependency> dependencies = DependencyReader.GetDependencies(assemblyFilename);
                         IEnumerable<DependencyRuleGroup> groups = ruleSetForAssembly.ExtractDependencyGroups();
-                        bool success = _checker.Check(groups, dependencies, _options.ShowUnusedQuestionableRules);
+                        bool success = _checker.Check(groups, dependencies, _options.ShowUnusedQuestionableRules, _options.EmitQuestionableDependenciesToErrorLog);
                         if (!success) {
                             return 3;
                         }
@@ -106,14 +106,15 @@ namespace NDepCheck {
             } finally {
                 DateTime end = DateTime.Now;
                 TimeSpan runtime = end.Subtract(start);
+                const string nDepCheckTook = "NDepCheck took ";
                 if (runtime < new TimeSpan(0, 0, 1)) {
-                    Log.WriteInfo("DC took " + runtime.Milliseconds + " ms.");
+                    Log.WriteInfo(nDepCheckTook + runtime.Milliseconds + " ms.");
                 } else if (runtime < new TimeSpan(0, 1, 0)) {
-                    Log.WriteInfo("DC took " + runtime.TotalSeconds + " s.");
+                    Log.WriteInfo(nDepCheckTook + runtime.TotalSeconds + " s.");
                 } else if (runtime < new TimeSpan(1, 0, 0)) {
-                    Log.WriteInfo("DC took " + runtime.Minutes + " min and " + runtime.Seconds + " s.");
+                    Log.WriteInfo(nDepCheckTook + runtime.Minutes + " min and " + runtime.Seconds + " s.");
                 } else {
-                    Log.WriteInfo("DC took " + runtime.TotalHours + " hours.");
+                    Log.WriteInfo(nDepCheckTook + runtime.TotalHours + " hours.");
                 }
             }
         }

--- a/src/NDepCheck/Properties/AssemblyInfo.cs
+++ b/src/NDepCheck/Properties/AssemblyInfo.cs
@@ -1,17 +1,16 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using NDepCheck;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("NDepCheck 1.8")]
+[assembly: AssemblyTitle("NDepCheck 1.9")]
 [assembly: AssemblyDescription("Dependency Checker for .NET")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("NDepCheck")]
-[assembly: AssemblyCopyright("Copyright HMMüller & Th. Freudenberg ©  2007..2012")]
+[assembly: AssemblyCopyright("Copyright HMMüller & Th. Freudenberg ©  2007..2014")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -30,5 +29,5 @@ using NDepCheck;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("1.8.0.0")]
-[assembly: AssemblyFileVersion("1.8.0.0")]
+[assembly: AssemblyVersion("1.9.0.0")]
+[assembly: AssemblyFileVersion("1.9.0.0")]


### PR DESCRIPTION
Build in IXOS gibt alle Dependencies als "Illegal" aus, auch die "Questionable". Wahrscheinlich irgendeine alte Version (sagt aber 1.8, während die 1.8 hier Questionable schrieb ...). Egal:
- neues Flag eingeführt, damit man Questionable auf Error-Log rausschreiben kann ... vielleicht nützlich (+ ein Unittest, der nur schaut, ob das Flag ok ist).
- Version auf 1.9 erhöht.
- minimale Refactorings

... eher Aktionismus als sinnvolle Änderung ;-)
